### PR TITLE
Fixed IE https support

### DIFF
--- a/src/le.js
+++ b/src/le.js
@@ -41,7 +41,7 @@ var LE = (function(window) {
             }
             // If we're relying on XDomainRequest, we
             // must adhere to the page's encryption scheme.
-            return window.location.protocol === "https" ? true : false;
+            return window.location.protocol === "https:" ? true : false;
         }();
         /** @type {Array.<string>} */
         var _backlog = [];


### PR DESCRIPTION
Bad comparison always returns http for IE even when the protocol is https due to missing colon.
