### PR TITLE
Fix AMD registration

### DIFF
--- a/src/le.js
+++ b/src/le.js
@@ -10,7 +10,7 @@
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(function() {
-            factory(root);
+            return factory(root);
         });
     } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but


### PR DESCRIPTION
Syntax to register as an anonymous module was incorrect.  The two-argument version of define only works when the first argument is an array of module ID's (strings) not objects.
