### PR TITLE
Patch for window reference in Browserify

### DIFF
--- a/deps/umd-extern.js
+++ b/deps/umd-extern.js
@@ -4,6 +4,9 @@ var module = {
 };
 var exports = null;
 
+// CommonJS/Browserify
+var global = null;
+
 // AMD
 var define = function(require, module){};
 define.amd = true;

--- a/src/le.js
+++ b/src/le.js
@@ -14,6 +14,12 @@
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like environments that support module.exports,
         // like Node.
+        if (typeof global === 'object') {
+            // Browserify. The calling object `this` does not reference window.
+            // `global` and `this` are equivalent in Node, preferring global
+            // adds support for Browserify.
+            root = global;
+        }
         module.exports = factory(root);
     } else {
         // Browser globals (root is window)


### PR DESCRIPTION
In Browserify the calling context of the module is an empty object. The reference to `window` is passed in as `global`. Since `global` and `this` are equivalent in Node it seems fine to use `global` when available.
- adds `global` to externs
- assigns `global` to `root` when present
