### PR TITLE
Suppress FF notice about not finding xml body (#24)

### DIFF
--- a/karma.conf-ci.js
+++ b/karma.conf-ci.js
@@ -6,7 +6,7 @@ module.exports = function(config) {
   var customLaunchers = {
     'SL_Chrome': {
       base: 'SauceLabs',
-      browserName: 'chrome'
+      browserName: 'Chrome'
     }
   };
 

--- a/karma.conf-ci.js
+++ b/karma.conf-ci.js
@@ -6,7 +6,7 @@ module.exports = function(config) {
   var customLaunchers = {
     'SL_Chrome': {
       base: 'SauceLabs',
-      browserName: 'Chrome'
+      browserName: 'chrome'
     }
   };
 

--- a/src/le.js
+++ b/src/le.js
@@ -269,6 +269,11 @@
                     request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
                     request.setRequestHeader('Content-type', 'text/json');
                 }
+                
+                if (request.overrideMimeType) {
+                    request.overrideMimeType('text');
+                }
+
                 request.send(data);
             }
         };


### PR DESCRIPTION
This is my first time poking around in this library so someone more intimate ought to confirm this works as I intend it to. The principle is sound, though, and one-off tests confirmed that FF stopped the nonsense because the override keeps it from assuming a 204 would have an xml body.