### PR TITLE
Enable better handling of Error object

### DIFF
--- a/src/le.js
+++ b/src/le.js
@@ -4,7 +4,7 @@
  */
 
 /*jslint browser:true*/
-/*global define, module, exports, console, global */
+/*global define, module, exports, console, global, JSON */
 
 /** @param {Object} window */
 (function (root, factory) {
@@ -270,7 +270,7 @@
                     request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
                     request.setRequestHeader('Content-type', 'application/json');
                 }
-                
+
                 if (request.overrideMimeType) {
                     request.overrideMimeType('text');
                 }

--- a/src/le.js
+++ b/src/le.js
@@ -197,6 +197,12 @@
 
                               if (typeof value === "undefined") {
                                 return "undefined";
+                              } else if (value instanceof Error) {
+                                return {
+                                    name: value.name,
+                                    message: value.message,
+                                    stack: value.stack
+                                };
                               } else if (typeof value === "object" && value !== null) {
                                 if (_indexOf(cache, value) !== -1) {
                                   // We've seen this object before;

--- a/test/leSpec.js
+++ b/test/leSpec.js
@@ -1,5 +1,5 @@
 /*jshint loopfunc:true*/
-/*globals describe, it, expect, LE, sinon, afterEach, beforeEach, jasmine, window, console, spyOn, XDomainRequest, XMLHttpRequest*/
+/*globals describe, it, expect, LE, sinon, afterEach, beforeEach, jasmine, window, console, spyOn, XDomainRequest, XMLHttpRequest, JSON*/
 var GLOBAL = this;
 var TOKEN = 'test_token';
 

--- a/test/leSpec.js
+++ b/test/leSpec.js
@@ -1,5 +1,5 @@
 /*jshint loopfunc:true*/
-/*globals describe, it, expect, LE, sinon, afterEach, beforeEach, jasmine, window, console, spyOn, XDomainRequest, XMLHttpRequest, JSON*/
+/*globals describe, it, expect, LE, sinon, afterEach, beforeEach, jasmine, window, console, navigator, spyOn, XDomainRequest, XMLHttpRequest, JSON*/
 var GLOBAL = this;
 var TOKEN = 'test_token';
 var FILENAME = 'leSpec.js';

--- a/test/leSpec.js
+++ b/test/leSpec.js
@@ -2,6 +2,7 @@
 /*globals describe, it, expect, LE, sinon, afterEach, beforeEach, jasmine, window, console, spyOn, XDomainRequest, XMLHttpRequest, JSON*/
 var GLOBAL = this;
 var TOKEN = 'test_token';
+var FILENAME = 'leSpec.js';
 
 function destroy() {
     LE.destroy('default');
@@ -91,6 +92,19 @@ describe('sending messages', function () {
         var event = this.getXhrJson(0).event;
         expect(event.undef).toBe('undefined');
         expect(event.nullVal).toBe(null);
+    });
+
+    it('logs Error object', function () {
+        LE.error(new Error('I am an error'));
+
+        var event = this.getXhrJson(0).event;
+
+        expect(event.message).toEqual('I am an error');
+        expect(event.name).toEqual('Error');
+
+        if (!navigator.appVersion.match(/PhantomJS/)) {
+          expect(event.stack).toMatch(FILENAME);
+        }
     });
 
     it('logs array with nullish values', function () {


### PR DESCRIPTION
When logging a native Error object with LE (eg. `LE.error(new Error('something has happened'))`), LE will send an empty object to the server, like this making the error disappear.

This fix will send the two universally accepted properties - `name` and `message` - together with the not so universal `stack` parameter.

In the test I'm checking for the user agent, to see if it is PhantomJS, the reason for this is that PhantomJS doesn't support the `stack` property on the Error object.

Also added some globals for jshint, to recognize `JSON` and `navigator` objects.