### PR TITLE
Add UserAgent to browser info

### DIFF
--- a/src/le.js
+++ b/src/le.js
@@ -130,6 +130,7 @@
               },
               browser: {
                 name: nav.appName,
+                user_agent: nav.userAgent,
                 version: nav.appVersion,
                 cookie_enabled: nav.cookieEnabled,
                 do_not_track: nav.doNotTrack


### PR DESCRIPTION
Log UserAgent in the browser object. 

FTR UserAgent is also a deprecated method and has been removed from Web Standards. As it stands today there is no way to retrieve browser information that is 100% accurate.